### PR TITLE
Allow GHC 9.12 and regenerate haskell-ci.yml

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241202
+# version: 0.19.20250315
 #
-# REGENDATA ("0.19.20241202",["github","cabal.project.ci"])
+# REGENDATA ("0.19.20250315",["github","cabal.project.ci"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -28,19 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -72,7 +77,7 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.40.0/x86_64-linux-ghcup-0.1.40.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |

--- a/demo/demo.cabal
+++ b/demo/demo.cabal
@@ -11,9 +11,10 @@ tested-with:        GHC==8.10.7
                   , GHC==9.0.2
                   , GHC==9.2.8
                   , GHC==9.4.8
-                  , GHC==9.6.5
-                  , GHC==9.8.2
+                  , GHC==9.6.7
+                  , GHC==9.8.4
                   , GHC==9.10.1
+                  , GHC==9.12.2
 
 common lang
   ghc-options:

--- a/lib/falsify.cabal
+++ b/lib/falsify.cabal
@@ -29,9 +29,10 @@ tested-with:        GHC==8.10.7
                   , GHC==9.0.2
                   , GHC==9.2.8
                   , GHC==9.4.8
-                  , GHC==9.6.5
-                  , GHC==9.8.2
+                  , GHC==9.6.7
+                  , GHC==9.8.4
                   , GHC==9.10.1
+                  , GHC==9.12.2
 
 source-repository head
   type:     git
@@ -43,7 +44,7 @@ common lang
       -Wredundant-constraints
       -Widentities
   build-depends:
-      base >= 4.12 && < 4.21
+      base >= 4.12 && < 4.22
   default-language:
       Haskell2010
   default-extensions:


### PR DESCRIPTION
While we're at it, bump the minor versions of the other GHCs used for testing.

GHC 9.6.7 is not yet recognized by haskell-ci, so we manually bump that field in haskell-ci.yml.